### PR TITLE
Adjust range of tag check in should_mark_hidden_tag

### DIFF
--- a/jni/core/skeymaster_asn1.c
+++ b/jni/core/skeymaster_asn1.c
@@ -205,7 +205,7 @@ int should_mark_hidden_tag(keymaster_tag_t tag)
     */
     if (0x90001451 == tag ||
         (0x900002c6 <= tag && tag < 0x900002ce) ||
-        (tag < 0x9000138f && 0x900003e8 >= tag)) {
+        (0x900003e8 <= tag && tag < 0x9000138f)) {
         return 1;
     }
 


### PR DESCRIPTION
Our team is working with your code and we noticed this if logical expression:
          
    `if (0x90001451 == tag || (0x900002c6 <= tag && tag < 0x900002ce) || (tag < 0x9000138f && 0x900003e8 >= tag))`

In the second predicate, `(tag < 0x9000138f && 0x900003e8 >= tag)`, the second condition seems to be included by the first, since 0x900003e8 is a smaller value than 0x9000138f. This predicate seems to translate to: 

    `(tag < 0x9000138f && tag <= 0x900003e8)`

 which is semantically equivalent to: `tag < 0x9000138f` because `tag <= 0x900003e8` is subsumed by the first comparison.

We speculate that given the context of the function, this line may instead be intended as:

   `if (0x90001451 == tag || (0x900002c6 <= tag && tag < 0x900002ce) || (0x900003e8 <= tag && tag < 0x9000138f))`

Do you agree / disagree? 

Irrespective of the answer, it seems the original form has an unnecessary component / expression.

Thank you!